### PR TITLE
Fix to create `Dependency` only once.

### DIFF
--- a/Sources/Pure/Configurator.swift
+++ b/Sources/Pure/Configurator.swift
@@ -4,9 +4,7 @@ open class Configurator<Module: ConfiguratorModule> {
   private let dependencyClosure: () -> Module.Dependency
 
   /// A static dependency of a module.
-  open var dependency: Module.Dependency {
-    return self.dependencyClosure()
-  }
+  open private(set) lazy var dependency: Module.Dependency = self.dependencyClosure()
 
   /// Creates an instance of `Configurator`.
   ///

--- a/Sources/Pure/Factory.swift
+++ b/Sources/Pure/Factory.swift
@@ -4,9 +4,7 @@ open class Factory<Module: FactoryModule> {
   private let dependencyClosure: () -> Module.Dependency
 
   /// A static dependency of a module.
-  open var dependency: Module.Dependency {
-    return self.dependencyClosure()
-  }
+  open private(set) lazy var dependency: Module.Dependency = self.dependencyClosure()
 
   /// Creates an instance of `Factory`.
   ///

--- a/Tests/PureTests/PureSpec.swift
+++ b/Tests/PureTests/PureSpec.swift
@@ -169,6 +169,24 @@ final class PureSpec: QuickSpec {
         expect(instance.dependency) == Void()
         expect(instance.payload) == Void()
       }
+
+      it("dependency should be initialized once") {
+        var dependencyInitializedCount = 0
+        let dependencyInitializer: () -> Dependency = {
+          dependencyInitializedCount += 1
+          return .init(
+            networking: "Networking B"
+          )
+        }
+        let instance = ConfiguratorFixture<Dependency, Void>()
+        let configurator = ConfiguratorFixture<Dependency, Void>.Configurator(dependency: dependencyInitializer())
+
+        for _ in 0..<4 {
+          configurator.configure(instance)
+        }
+
+        expect(dependencyInitializedCount) == 1
+      }
     }
   }
 }

--- a/Tests/PureTests/PureSpec.swift
+++ b/Tests/PureTests/PureSpec.swift
@@ -114,6 +114,23 @@ final class PureSpec: QuickSpec {
         expect(instance.dependency) == Void()
         expect(instance.payload) == Void()
       }
+
+      it("dependency should be initialized once") {
+        var dependencyInitializedCount = 0
+        let dependencyInitializer: () -> Dependency = {
+          dependencyInitializedCount += 1
+          return .init(
+            networking: "Networking B"
+          )
+        }
+        let factory = FactoryFixture<Dependency, Void>.Factory(dependency: dependencyInitializer())
+
+        for _ in 0..<4 {
+          _ = factory.create()
+        }
+
+        expect(dependencyInitializedCount) == 1
+      }
     }
 
     describe("a configurator") {


### PR DESCRIPTION
Dependency should be initialized only once because it is static, but it is being initialized every time it uses dependency.

I fixed to initialize dependency only once using `lazy var`.

Thanks to @OhKanghoon 