### PR TITLE
Update package dependencies (Quick & Nimble)

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,21 +2,39 @@
   "object": {
     "pins": [
       {
-        "package": "Nimble",
-        "repositoryURL": "https://github.com/devxoul/Nimble.git",
+        "package": "CwlCatchException",
+        "repositoryURL": "https://github.com/mattgallagher/CwlCatchException.git",
         "state": {
-          "branch": "swift-5",
-          "revision": "8655fea1802b0c4269df31b14d1aadf2cd77b4e8",
-          "version": null
+          "branch": null,
+          "revision": "7cd2f8cacc4d22f21bc0b2309c3b18acf7957b66",
+          "version": "1.2.0"
+        }
+      },
+      {
+        "package": "CwlPreconditionTesting",
+        "repositoryURL": "https://github.com/mattgallagher/CwlPreconditionTesting.git",
+        "state": {
+          "branch": null,
+          "revision": "c228db5d2ad1b01ebc84435e823e6cca4e3db98b",
+          "version": "1.2.0"
+        }
+      },
+      {
+        "package": "Nimble",
+        "repositoryURL": "https://github.com/Quick/Nimble.git",
+        "state": {
+          "branch": null,
+          "revision": "6abeb3f5c03beba2b9e4dbe20886e773b5b629b6",
+          "version": "8.0.4"
         }
       },
       {
         "package": "Quick",
-        "repositoryURL": "https://github.com/devxoul/Quick.git",
+        "repositoryURL": "https://github.com/Quick/Quick.git",
         "state": {
-          "branch": "swift-5",
-          "revision": "98b15d63d8dcb41f025b662557ce785275fe3295",
-          "version": null
+          "branch": null,
+          "revision": "33682c2f6230c60614861dfc61df267e11a1602f",
+          "version": "2.2.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -9,8 +9,8 @@ let package = Package(
   ],
   products: [.library(name: "Pure", targets: ["Pure"])],
   dependencies: [
-    .package(url: "https://github.com/devxoul/Quick.git", .branch("swift-5")),
-    .package(url: "https://github.com/devxoul/Nimble.git", .branch("swift-5")),
+    .package(url: "https://github.com/Quick/Quick.git", .upToNextMajor(from: "2.0.0")),
+    .package(url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "8.0.0")),
   ],
   targets: [
     .target(name: "Pure", dependencies: []),


### PR DESCRIPTION
[`Quick (2.0.0)`](https://github.com/Quick/Quick/releases/tag/v2.0.0) and [`Nimble (8.0.0)`](https://github.com/Quick/Nimble/releases/tag/v8.0.0) support swift 5!

SPM can not resolve dependencies.
Refer this message
>Showing All Messages
: the package pure[https://github.com/devxoul/pure] @ 1.1.1 contains incompatible dependencies:
    quick[https://github.com/devxoul/Quick.git] @ swift-5
    nimble[https://github.com/devxoul/Nimble.git] @ swift-5


