### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ func application(_ application: UIApplication, didReceiveRemoteNotification user
 
 `AppDelegate` is one of the most important class in a Cocoa application. It resolves an app dependency and handles app events. It can be easily tested as we separated the app dependency.
 
-This is an example test case of `AppDelegate`. It verifies that `AppDepegate` correctly injects root view controller's dependency in `application(_:didFinishLaunchingWithOptions)`.
+This is an example test case of `AppDelegate`. It verifies that `AppDelegate` correctly injects root view controller's dependency in `application(_:didFinishLaunchingWithOptions)`.
 
 ```swift
 class AppDelegateTests: XCTestCase {


### PR DESCRIPTION
Hello😃 @devxoul 
I found a typo in a good document.😂
I think real meaning is maybe 'AppDelegate'.

<img width="1382" alt="스크린샷 2019-12-10 오후 10 10 03" src="https://user-images.githubusercontent.com/45457678/70578956-8a076f00-1bf2-11ea-9fae-9ff0f44a0212.png">


Thank you for your beautiful openSource.🥰